### PR TITLE
fix(ssl): use SSL_CERT_* vars from .env if exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cert/certificate.*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-cert/certificate.*

--- a/cert/.gitignore
+++ b/cert/.gitignore
@@ -1,0 +1,1 @@
+certificate.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./cert/certificate.crt:/usr/local/apache2/conf/server.crt
-      - ./cert/certificate.key:/usr/local/apache2/conf/server.key
+      - ${SSL_CERT_CRT:-./cert/certificate.crt}:/usr/local/apache2/conf/server.crt
+      - ${SSL_CERT_KEY:-./cert/certificate.key}:/usr/local/apache2/conf/server.key
       - /etc/localtime:/etc/localtime:ro
       - /var/run/docker.sock:/var/run/docker.sock
 


### PR DESCRIPTION
Use ssl certificate files defined in .env if exists else a default path.
The .env and cert files exist on server:
```
SSL_CERT_CRT=/etc/ssl/panel-lemanique-test.epfl.ch.crt.pem
SSL_CERT_KEY=/etc/ssl/panel-lemanique-test.epfl.ch.key
```